### PR TITLE
refactor(lines): linestyle total lengths match up better

### DIFF
--- a/src/plastik/lines.py
+++ b/src/plastik/lines.py
@@ -17,12 +17,11 @@ def get_linestyle_dict() -> dict[str, str | tuple]:
     See <https://matplotlib.org/stable/gallery/lines_bars_and_markers/linestyles.html>.
     """
     return {
-        "dotted": ":",
-        "dashed": "--",
-        "dashdot": "-.",
-        "long dash with offset": (5, (10, 3)),
-        "densely dashed": (0, (5, 1)),
-        "densely dashdotted": (0, (3, 1, 1, 1)),
+        "dotted": (0, (1, 1)),  # :
+        "dashed": (0, (3, 1)),  # --
+        "dashdot": (0, (5, 1, 1, 1)),  # -.
+        "long dash": (0, (6, 2)),
+        "densely dashdotted": (0, (4, 2, 1, 2)),
         "densely dashdotdotted": (0, (3, 1, 1, 1, 1, 1)),
     }
 
@@ -39,9 +38,9 @@ def get_linestyle_cycle() -> itertools.cycle:
     --------
     >>> ls = get_linestyle_cycle()
     >>> next(ls)
-    :
+    (0, (1, 1))
 
     >>> next(ls)
-    --
+    (0, (3, 1))
     """
     return itertools.cycle(list(get_linestyle_dict().values()))


### PR DESCRIPTION
When cycling over all line styles, they now match up better such that a handle length of 2.48 with font size 8 make them all show fully with at least one repetition of their pattern.